### PR TITLE
fix: grant packages:write permission for GitHub Packages publishing

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,7 +23,7 @@ jobs:
       security-events: write
       actions: read
       contents: read
-      packages: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- The `build` job had `packages: read`, which prevented publishing to GitHub Packages from candidate and final builds (HTTP 403)
- Permissions in the calling workflow are ignored for jobs defined inside a reusable workflow — the fix must live here